### PR TITLE
Fix missing config watch and compat with chroot

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -612,8 +612,8 @@ impl Client {
 
     /// Gets stat and data for ZooKeeper config node, that is node with path "/zookeeper/config".
     pub async fn get_and_watch_config(&self) -> Result<(Vec<u8>, Stat, OneshotWatcher), Error> {
-        let (data, stat, watcher) = self.get_data_internally(Self::CONFIG_NODE, Default::default(), false).await?;
-        Ok((data, stat, watcher.into_oneshot(&self.root)))
+        let (data, stat, watcher) = self.get_data_internally(Self::CONFIG_NODE, Default::default(), true).await?;
+        Ok((data, stat, watcher.into_oneshot("")))
     }
 
     /// Updates ZooKeeper ensemble.


### PR DESCRIPTION
Currently, `get_and_watch_config` has two problems:
* It requires no watch from `get_data_internally`.
* It strips watch path using `root` while it should not.
