### PR TITLE
fix: Client::create does not work on ZooKeeper 3.4.x

### DIFF
--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -85,7 +85,7 @@ pub struct WatchedEvent {
     ///
     /// # Notable behaviors
     /// * This feature was shipped in 3.9.0, `zxid` wil be [WatchedEvent::NO_ZXID] for earlier versions. See [ZOOKEEPER-4655].
-    /// * It is possible to receive multiple events with same `zxid` and even same `path` due to [MultiWriter]. See [ZOOKEEPER-4695].
+    /// * It is possible to receive multiple events with same `zxid` and even same `path` due to [crate::MultiWriter]. See [ZOOKEEPER-4695].
     ///
     /// [ZOOKEEPER-4655]: https://issues.apache.org/jira/browse/ZOOKEEPER-4655
     /// [ZOOKEEPER-4695]: https://issues.apache.org/jira/browse/ZOOKEEPER-4695


### PR DESCRIPTION
This commit adds client side assumed ZooKeeper version so that client
can fallback to `OpCode::create` instead of `OpCode::create2` on 3.4.x.

Resolves #18.
