### PR TITLE
Ignore failed deletions of non-existing watchers.

### DIFF
--- a/src/proto/error_code.rs
+++ b/src/proto/error_code.rs
@@ -49,7 +49,7 @@ pub enum ErrorCode {
     AuthFailed = -115,
     SessionMoved = -118,
     NotReadOnly = -119,
-    NoWatcher = -122,
+    NoWatcher = -121,
     ReconfigDisabled = -123,
     SessionClosedRequireSaslAuth = -124,
     QuotaExceeded = -125,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -281,6 +281,9 @@ impl Session {
             return Err(Error::SessionExpired);
         } else if header.err == ErrorCode::AuthFailed.into() {
             return Err(Error::AuthFailed);
+        } else if header.err == ErrorCode::NoWatcher.into() {
+            log::debug!("attempted to delete non-existing watcher.");
+            return Ok(());
         }
         if header.xid == PredefinedXid::Notification.into() {
             self.handle_notification(header.zxid, body, depot)?;


### PR DESCRIPTION
One-shot watches get deleted on our end when they are dropped, but we sometimes still get a notification for the watches from zookeeper after the watchers are dropped.

In those cases, we send a RemoveWatch request to catch any leaking persistent watchers, but since the watcher does not exist, it results in a NoWatcher error.

Workaround for #22