### PR TITLE
fix: AuthFailed not reported eagerly in Connector::connect

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -100,6 +100,10 @@ pub struct OtherError {
 }
 
 impl Error {
+    pub(crate) fn is_terminated(&self) -> bool {
+        matches!(self, Self::NoHosts | Self::SessionExpired | Self::AuthFailed | Self::ClientClosed)
+    }
+
     pub(crate) fn has_no_data_change(&self) -> bool {
         match self {
             Self::NoNode


### PR DESCRIPTION
`AuthFailed` is a terminal error. It should be reported eagerly if
possible. Currently, there are two problems:
* `AuthFailed` is not reported in connection establishment.
* Session could immediately fail after successful `connect`.
