### PR TITLE
docs: state that no session disconnected event before closed

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -292,14 +292,10 @@ impl Session {
         requester: &mut mpsc::UnboundedReceiver<SessionOperation>,
         unwatch_requester: &mut mpsc::UnboundedReceiver<(WatcherId, StateResponser)>,
     ) {
-        if let Err(err) = self.serve_session(endpoints, &mut conn, buf, depot, requester, unwatch_requester).await {
-            self.resolve_serve_error(&err);
-            info!("enter state {} due to {}", self.session_state, err);
-            depot.error(&err);
-        } else {
-            self.change_state(SessionState::Disconnected);
-            self.change_state(SessionState::Closed);
-        }
+        let err = self.serve_session(endpoints, &mut conn, buf, depot, requester, unwatch_requester).await.unwrap_err();
+        self.resolve_serve_error(&err);
+        info!("enter state {} due to {}", self.session_state, err);
+        depot.error(&err);
     }
 
     fn handle_notification(&mut self, zxid: i64, mut body: &[u8], depot: &mut Depot) -> Result<(), Error> {

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -61,6 +61,11 @@ impl SessionInfo {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, strum::Display)]
 pub enum SessionState {
     /// Intermediate state states that client is disconnected from zookeeper cluster.
+    ///
+    /// In case of all clients dropped, this state is not reported. This differs from Java client
+    /// which is indeterminate currently. See [ZOOKEEPER-4702][].
+    ///
+    /// [ZOOKEEPER-4702]: https://issues.apache.org/jira/browse/ZOOKEEPER-4702
     Disconnected,
 
     /// Intermediate state states that client has recovered from disconnected state.

--- a/tests/zookeeper.rs
+++ b/tests/zookeeper.rs
@@ -1823,7 +1823,6 @@ async fn test_client_drop() {
     let client = cluster.client(None).await;
 
     let mut state_watcher = client.state_watcher();
-    tokio::time::sleep(Duration::from_secs(20)).await;
     let session = client.into_session();
     assert_eq!(zk::SessionState::Closed, state_watcher.changed().await);
 


### PR DESCRIPTION
Though there is code path to deliver `Disconnected` before `Closed`, but
it is unreachable and several tests have assert immediate `Closed` after
clients dropped, e.g. `test_state_watcher`, `test_client_drop` and
`test_client_detach`.

I favor immediate `Closed` now since it states the truth and avoid false
reactions against `Disconnected`. Whoever want a `Disconnected` could do
it themselves.
