### PR TITLE
Upgrade rsasl to 2.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,10 @@ webpki-roots = { version = "0.26.1", optional = true }
 derive-where = "1.2.7"
 fastrand = "2.0.2"
 tracing = "0.1.40"
-rsasl = { version = "2.0.1", default-features = false, features = ["provider", "config_builder", "registry_static", "std"], optional = true }
+rsasl = { version = "2.2.0", default-features = false, features = ["provider", "config_builder", "registry_static", "std"], optional = true }
 md5 = { version = "0.7.0", optional = true }
 hex = { version = "0.4.3", optional = true }
-linkme = { version = "0.2", optional = true }
+linkme = { version = "0.3", optional = true }
 async-io = "2.3.2"
 futures = "0.3.30"
 async-net = "2.0.0"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -859,7 +859,7 @@ impl Client {
     /// # Cautions
     /// * Holds returned watcher without polling events may result in memory burst.
     /// * At the time of written, ZooKeeper [ZOOKEEPER-4466][] does not support oneshot and
-    /// persistent watch on same path.
+    ///   persistent watch on same path.
     /// * Persistent watch could lose events during reconnection due to [ZOOKEEPER-4698][].
     ///
     /// [ZOOKEEPER-4466]: https://issues.apache.org/jira/browse/ZOOKEEPER-4466
@@ -1137,8 +1137,8 @@ impl Client {
     ///
     /// # Error handling on [Error::ConnectionLoss]
     /// * If connection loss during lock path creation, this method will find out the created lock
-    /// path if creation success by matching prefix for [LockPrefix::new_curator] or ephemeral
-    /// owner for others.
+    ///   path if creation success by matching prefix for [LockPrefix::new_curator] or ephemeral
+    ///   owner for others.
     /// * Retry all other operations on connection loss.
     ///
     /// # Notable issues
@@ -1287,7 +1287,7 @@ impl<'a> LockPrefix<'a> {
     ///
     /// # Notable usages
     /// * Uses "{dir}/x-{session_id}-" as `prefix` and "x-" or "" as `name` for ZooKeeper java
-    /// client's [WriteLock].
+    ///   client's [WriteLock].
     ///
     /// [WriteLock]: https://github.com/apache/zookeeper/blob/release-3.9.0/zookeeper-recipes/zookeeper-recipes-lock/src/main/java/org/apache/zookeeper/recipes/lock/WriteLock.java#L212
     pub fn new_custom(prefix: String, name: &'a str) -> Result<Self> {

--- a/src/sasl/mechanisms/digest_md5.rs
+++ b/src/sasl/mechanisms/digest_md5.rs
@@ -2,29 +2,13 @@ use std::borrow::Cow;
 use std::io::Write;
 
 use md5::Context as Md5Hasher;
-use rsasl::mechanism::{
-    Authentication,
-    Demand,
-    DemandReply,
-    MechanismData,
-    MechanismError,
-    MechanismErrorKind,
-    Provider,
-};
+use rsasl::mechanism::{Authentication, EmptyProvider, MechanismData, MechanismError, MechanismErrorKind};
 use rsasl::prelude::*;
 use rsasl::property::{AuthId, Password, Realm};
 use rsasl::registry::{distributed_slice, Matches, Named, Side, MECHANISMS};
 use thiserror::Error;
 
 pub(crate) type Result<T, E = crate::error::Error> = std::result::Result<T, E>;
-
-#[derive(Debug)]
-pub struct EmptyProvider;
-impl Provider<'_> for EmptyProvider {
-    fn provide(&self, _: &mut Demand<'_>) -> DemandReply<()> {
-        DemandReply::Continue(())
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, strum::Display)]
 enum ValueKind {

--- a/src/session/connection.rs
+++ b/src/session/connection.rs
@@ -40,7 +40,8 @@ pub trait AsyncReadToBuf: AsyncReadExt {
     where
         Self: Unpin, {
         let chunk = buf.chunk_mut();
-        let read_to = unsafe { std::mem::transmute(chunk.as_uninit_slice_mut()) };
+        let read_to =
+            unsafe { std::mem::transmute::<&mut [std::mem::MaybeUninit<u8>], &mut [u8]>(chunk.as_uninit_slice_mut()) };
         let n = self.read(read_to).await?;
         if n != 0 {
             unsafe {
@@ -246,7 +247,10 @@ impl Connector {
             i += 1;
             match self.connect(endpoint, &mut deadline).await {
                 Ok(conn) => match conn.command_isro().await {
-                    Ok(true) => return Some(unsafe { std::mem::transmute(endpoint) }),
+                    // Safety: https://github.com/rust-lang/rust/issues/74068
+                    Ok(true) => {
+                        return Some(unsafe { std::mem::transmute::<EndpointRef<'_>, EndpointRef<'_>>(endpoint) })
+                    },
                     Ok(false) => trace!("succeeds to contact readonly {}", endpoint),
                     Err(err) => trace!(%err, r#"fails to complete "isro" to {}"#, endpoint),
                 },

--- a/src/session/request.rs
+++ b/src/session/request.rs
@@ -18,8 +18,12 @@ pub struct MarshalledRequest(pub Vec<u8>);
 #[derive(Clone, Copy, Debug)]
 pub enum OpStat<'a> {
     None,
+    #[allow(dead_code)]
     Path(&'a str),
-    Watch { path: &'a str, mode: WatchMode },
+    Watch {
+        path: &'a str,
+        mode: WatchMode,
+    },
 }
 
 impl MarshalledRequest {


### PR DESCRIPTION
- Upgrade rsasl to 2.2.0 to fix unexported types
- Fix dead_code lint error
