### PR TITLE
chore: mark futures-rustls as an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.76"
 
 [features]
 default = []
-tls = ["rustls", "rustls-pemfile", "webpki-roots"]
+tls = ["rustls", "rustls-pemfile", "webpki-roots", "futures-rustls"]
 sasl = ["sasl-gssapi", "sasl-digest-md5"]
 sasl-digest-md5 = ["rsasl/unstable_custom_mechanism", "md5", "linkme", "hex"]
 sasl-gssapi = ["rsasl/gssapi"]
@@ -50,7 +50,7 @@ linkme = { version = "0.3", optional = true }
 async-io = "2.3.2"
 futures = "0.3.30"
 async-net = "2.0.0"
-futures-rustls = "0.26.0"
+futures-rustls = { version = "0.26.0", optional = true }
 futures-lite = "2.3.0"
 asyncs = "0.3.0"
 


### PR DESCRIPTION
👋🏾 Hi! 

This project was a godsend for me and I just wanted to share my appreciation. I have a scenario where I'm not using TLS natively through the library because my service mesh is providing that functionality -- that's neither here nor there but even without TLS, the library `futures-rustls` gets pulled in. 

That library itself has been pretty harmless, but transitively it pulls in https://github.com/aws/aws-lc-rs by default which is pretty unstable even for common processor architectures like `aarch64`. 

Would you be open to marking this as optional as well to make the non-/external-TLS use case more stable?

Thank you again -- this project was just what I needed!