### PR TITLE
Drop Mozilla tls roots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ rust-version = "1.76"
 [features]
 default = []
 tls = ["rustls", "rustls-pemfile", "futures-rustls"]
-tls-mozilla-roots = ["tls", "webpki-roots"]
 sasl = ["sasl-gssapi", "sasl-digest-md5"]
 sasl-digest-md5 = ["rsasl/unstable_custom_mechanism", "md5", "linkme", "hex"]
 sasl-gssapi = ["rsasl/gssapi"]
@@ -40,7 +39,6 @@ either = "1.9.0"
 uuid = { version = "1.4.1", features = ["v4"] }
 rustls = { version =  "0.23.2", optional = true }
 rustls-pemfile = { version = "2", optional = true }
-webpki-roots = { version = "1.0.1", optional = true }
 derive-where = "1.2.7"
 fastrand = "2.0.2"
 tracing = "0.1.40"

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -107,15 +107,6 @@ impl TlsOptions {
         Self { ca_certs: RootCertStore::empty(), identity: None, hostname_verification: true }
     }
 
-    /// Trusts root certificates trusted by Mozilla.
-    ///
-    /// See [webpki-roots](https://docs.rs/webpki-roots) for more.
-    #[cfg(feature = "tls-mozilla-roots")]
-    pub fn with_mozilla_roots(mut self) -> Self {
-        self.ca_certs.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-        self
-    }
-
     /// Disables hostname verification in tls handshake.
     ///
     /// # Safety


### PR DESCRIPTION
There are few chances that ZooKeeper servers are certificated by those ca
directly. One could specify them by serializing them to pem anyway.
