### PR TITLE
Add feature to allow enabling FIPS in rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.76"
 [features]
 default = []
 tls = ["rustls", "rustls-pemfile", "futures-rustls"]
+fips = ["rustls?/fips"]
 sasl = ["sasl-gssapi", "sasl-digest-md5"]
 sasl-digest-md5 = ["rsasl/unstable_custom_mechanism", "md5", "linkme", "hex"]
 sasl-gssapi = ["rsasl/gssapi"]


### PR DESCRIPTION
In order to be able to enable fips when depending on the zookeeper client we need to allow setting the rustls feature.