### PR TITLE
Add runtime option and compile time feature to enable fips mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.76"
 default = []
 tls = ["rustls", "rustls-webpki", "rustls-pemfile", "futures-rustls"]
 fips = ["rustls?/fips"]
+fips-only = ["fips"]
 sasl = ["sasl-gssapi", "sasl-digest-md5"]
 sasl-digest-md5 = ["rsasl/unstable_custom_mechanism", "md5", "linkme", "hex"]
 sasl-gssapi = ["rsasl/gssapi"]
@@ -73,6 +74,8 @@ rustls-pki-types = "1.12.0"
 x509-parser = "0.17.0"
 atomic-write-file = "0.2.3"
 notify = "7.0.0"
+test-fork = "0.1.3"
+rstest = "0.25.0"
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
@@ -81,6 +84,10 @@ denylist = ["tokio", "smol", "async-global-executor"]
 [package.metadata.cargo-feature-combinations]
 isolated_feature_sets = [
     ["tls", "sasl"],
+]
+include_feature_sets = [
+    ["tls", "fips"],
+    ["tls", "fips-only"],
 ]
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@
 //!
 //! ## Feature flags
 //! * `tls`: Toggle TLS support.
+//! * `fips`: Toggle TLS FIPS mode support. See also [TlsOptions::with_fips].
+//! * `fips-only`: Force TLS FIPS mode. This should be considered as an application only feature to
+//!   fulfill security requirement at global level.
 //! * `sasl`: Toggle SASL support.
 //! * `sasl-gssapi`: Toggle only GSSAPI SASL support. This relies on binding package `libgssapi-sys`.
 //! * `sasl-digest-md5`: Toggle only DIGEST-MD5 SASL support.


### PR DESCRIPTION
Usually, it is enough to enable FIPS mode by simply enabling feature
"fips" as the global crypto provider probably will be FIPS compatible.
But this is not guaranteed, as the global crypto provider could be
customized deliberately on purpose.

By introducing `TlsOptions::with_fips`, one could enable FIPS mode
explicitly at runtime with feature "fips" while keeping agnostic to
global settings.

In contrast, "fips-only" feature will enable fips mode in compile time.
`TlsOptions::with_fips` will be a nop in this case.