### PR TITLE
Render Error::NoWatcher for Watcher::remove if no watcher in client side

### DIFF
--- a/src/session/watch.rs
+++ b/src/session/watch.rs
@@ -386,7 +386,7 @@ impl WatchManager {
         if let Some((path, mode)) = self.try_remove_watcher(watcher_id, depot) {
             depot.push_remove_watch(path, mode, responser);
         } else {
-            responser.send_empty();
+            responser.send(Err(Error::NoWatcher));
         }
     }
 


### PR DESCRIPTION
This eases test assertions.
