### PR TITLE
fix: send 16-byte zero password in initial ConnectRequest for ClickHo…

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -107,7 +107,7 @@ impl Builder {
                 Span::current().record("session", display(session.id()));
                 session
             },
-            None => SessionInfo::new(SessionId(0), Vec::with_capacity(PASSWORD_LEN)),
+            None => SessionInfo::new(SessionId(0), vec![0; PASSWORD_LEN]),
         };
         if self.session_timeout < Duration::ZERO {
             return Err(Error::BadArguments(&"session timeout must not be negative"));


### PR DESCRIPTION
…use Keeper compatibility

Vec::with_capacity(PASSWORD_LEN) creates a Vec with capacity 16 but length 0, causing the handshake to send an empty password field (length=0). ClickHouse Keeper strictly validates that the password field is exactly 16 bytes and rejects connections with any other size (ZMARSHALLINGERROR).

Changed to vec![0; PASSWORD_LEN] which creates 16 zero bytes, matching the ZooKeeper protocol specification and the behavior of the official Java client.

This fix has no impact on Apache ZooKeeper (which accepts both sizes) and only affects new session establishment - reconnections already use the server-provided password.