### PR TITLE
transport: add turmoil support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ sasl-gssapi = ["rsasl/gssapi"]
 tokio = ["asyncs/tokio"]
 smol = ["asyncs/smol"]
 async-global-executor = ["asyncs/async-global-executor"]
+turmoil = ["dep:turmoil", "dep:tokio-util", "tokio"]
 
 [dependencies]
 bytes = "1.1.0"
@@ -55,6 +56,8 @@ async-net = "2.0.0"
 futures-rustls = { version = "0.26.0", optional = true }
 futures-lite = "2.3.0"
 asyncs = "0.4.0"
+tokio-util = { version = "0.7", features = ["compat"], optional = true }
+turmoil = { version = "0.7.1", optional = true }
 
 [dev-dependencies]
 test-log = { version = "0.2.18", features = ["log", "trace"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 //! * `sasl`: Toggle SASL support.
 //! * `sasl-gssapi`: Toggle only GSSAPI SASL support. This relies on binding package `libgssapi-sys`.
 //! * `sasl-digest-md5`: Toggle only DIGEST-MD5 SASL support.
+//! * `turmoil`: Toggle simulated networking support via `turmoil`.
 //!
 //! ## Async runtime support
 //! This library uses [asyncs](https://docs.rs/asyncs) and [spawns](https://docs.rs/spawns) to
@@ -29,6 +30,9 @@
 //! * `tokio`: Toggle support for [tokio](https://docs.rs/tokio).
 //! * `smol`: Toggle support for [smol](https://docs.rs/smol) builtin global executor.
 //! * `async-global-executor`: Toggle support for [async-global-executor](https://docs.rs/async-global-executor).
+//!
+//! `turmoil` currently builds on the `tokio` runtime support and adapts simulated sockets into the
+//! crate's existing `futures::io` transport layer.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
@@ -38,6 +42,7 @@ mod client;
 mod deadline;
 mod endpoint;
 mod error;
+mod net;
 mod proto;
 mod record;
 #[cfg(any(feature = "sasl-digest-md5", feature = "sasl-gssapi"))]

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,0 +1,9 @@
+#[cfg(not(feature = "turmoil"))]
+mod async_net;
+#[cfg(feature = "turmoil")]
+mod turmoil;
+
+#[cfg(not(feature = "turmoil"))]
+pub(crate) use async_net::{connect, TcpStream};
+#[cfg(feature = "turmoil")]
+pub(crate) use turmoil::{connect, TcpStream};

--- a/src/net/async_net.rs
+++ b/src/net/async_net.rs
@@ -1,0 +1,5 @@
+pub(crate) type TcpStream = async_net::TcpStream;
+
+pub(crate) async fn connect(host: &str, port: u16) -> std::io::Result<TcpStream> {
+    TcpStream::connect((host, port)).await
+}

--- a/src/net/turmoil.rs
+++ b/src/net/turmoil.rs
@@ -1,0 +1,7 @@
+use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
+
+pub(crate) type TcpStream = Compat<turmoil::net::TcpStream>;
+
+pub(crate) async fn connect(host: &str, port: u16) -> std::io::Result<TcpStream> {
+    turmoil::net::TcpStream::connect((host, port)).await.map(TokioAsyncReadCompatExt::compat)
+}

--- a/src/session/connection.rs
+++ b/src/session/connection.rs
@@ -4,7 +4,6 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use async_io::Timer;
-use async_net::TcpStream;
 use asyncs::select;
 use bytes::buf::BufMut;
 use futures::io::BufReader;
@@ -17,14 +16,15 @@ use tracing::{debug, trace};
 
 use crate::deadline::Deadline;
 use crate::endpoint::{EndpointRef, IterableEndpoints};
+use crate::net;
 #[cfg(feature = "tls")]
 use crate::tls::TlsClient;
 
 #[derive(Debug)]
 pub enum Connection {
-    Raw(TcpStream),
+    Raw(net::TcpStream),
     #[cfg(feature = "tls")]
-    Tls(Box<TlsStream<TcpStream>>),
+    Tls(Box<TlsStream<net::TcpStream>>),
 }
 
 pub trait AsyncReadToBuf: AsyncReadExt {
@@ -123,7 +123,7 @@ impl AsyncWrite for ConnWriter<'_> {
 }
 
 impl Connection {
-    pub fn new_raw(stream: TcpStream) -> Self {
+    pub fn new_raw(stream: net::TcpStream) -> Self {
         Self::Raw(stream)
     }
 
@@ -134,7 +134,7 @@ impl Connection {
     }
 
     #[cfg(feature = "tls")]
-    pub fn new_tls(stream: TlsStream<TcpStream>) -> Self {
+    pub fn new_tls(stream: TlsStream<net::TcpStream>) -> Self {
         Self::Tls(stream.into())
     }
 
@@ -198,7 +198,7 @@ impl Connector {
             #[cfg(not(feature = "tls"))]
             return Err(Error::new(ErrorKind::Unsupported, "tls not supported"));
         }
-        TcpStream::connect((endpoint.host, endpoint.port)).await.map(Connection::new_raw)
+        net::connect(endpoint.host, endpoint.port).await.map(Connection::new_raw)
     }
 
     pub async fn connect(&self, endpoint: EndpointRef<'_>, deadline: &mut Deadline) -> Result<Connection> {
@@ -260,5 +260,43 @@ mod tests {
         let endpoint = EndpointRef::new("host1", 2181, true);
         let err = connector.connect(endpoint, &mut Deadline::never()).await.unwrap_err();
         assert_eq!(err.kind(), ErrorKind::Unsupported);
+    }
+
+    #[cfg(feature = "turmoil")]
+    #[test]
+    fn connector_connects_over_turmoil() -> turmoil::Result {
+        use std::time::Duration;
+
+        use futures_lite::{AsyncReadExt, AsyncWriteExt};
+        use tokio_util::compat::TokioAsyncReadCompatExt;
+        use turmoil::{net::TcpListener, Builder};
+
+        let mut sim = Builder::new().simulation_duration(Duration::from_secs(10)).build();
+
+        sim.host("zk", || async move {
+            let listener = TcpListener::bind("0.0.0.0:2181").await?;
+            let (stream, _) = listener.accept().await?;
+            let mut stream = stream.compat();
+
+            let mut request = [0; 4];
+            stream.read_exact(&mut request).await?;
+            assert_eq!(&request, b"isro");
+
+            stream.write_all(b"rw").await?;
+            stream.flush().await?;
+            Ok(())
+        });
+
+        sim.client("client", async move {
+            let connector = Connector::new();
+            let endpoint = EndpointRef::new("zk", 2181, false);
+            let mut deadline = Deadline::never();
+            let conn = connector.connect(endpoint, &mut deadline).await.unwrap();
+
+            assert!(conn.command_isro().await.unwrap());
+            Ok(())
+        });
+
+        sim.run()
     }
 }

--- a/src/tls/client.rs
+++ b/src/tls/client.rs
@@ -1,6 +1,5 @@
 use std::sync::{Arc, RwLock};
 
-use async_net::TcpStream;
 use futures_rustls::client::TlsStream;
 use futures_rustls::TlsConnector;
 use rustls::client::WebPkiServerVerifier;
@@ -11,6 +10,7 @@ use tracing::warn;
 use super::{NoHostnameVerificationServerCertVerifier, TlsCerts, TlsClientOptions, TlsDynamicCerts, TlsInnerCerts};
 use crate::client::Result;
 use crate::error::Error;
+use crate::net;
 
 struct TlsDynamicConnector {
     config: RwLock<(u64, Arc<ClientConfig>)>,
@@ -76,7 +76,11 @@ enum TlsInnerClient {
 }
 
 impl TlsInnerClient {
-    async fn connect(&self, domain: ServerName<'static>, stream: TcpStream) -> std::io::Result<TlsStream<TcpStream>> {
+    async fn connect(
+        &self,
+        domain: ServerName<'static>,
+        stream: net::TcpStream,
+    ) -> std::io::Result<TlsStream<net::TcpStream>> {
         match self {
             Self::Static(connector) => connector.connect(domain, stream).await,
             Self::Dynamic(connector) => {
@@ -162,8 +166,8 @@ impl TlsClient {
         }
     }
 
-    pub async fn connect(&self, host: &str, port: u16) -> std::io::Result<TlsStream<TcpStream>> {
-        let stream = TcpStream::connect((host, port)).await?;
+    pub async fn connect(&self, host: &str, port: u16) -> std::io::Result<TlsStream<net::TcpStream>> {
+        let stream = net::connect(host, port).await?;
         let domain = ServerName::try_from(host).unwrap().to_owned();
         self.inner.connect(domain, stream).await
     }


### PR DESCRIPTION
this PR adds optional turmoil socket support to be able to run the client within a turmoil simulation. 

 I’d like to use this client in deterministic simulation tests, where I can exercise connection loss, partitions, delayed traffic, retries, and session behavior without relying on timing-sensitive real sockets or external ZooKeeper infrastructure. Turmoil is a good fit for that kind of coverage, and this change keeps the support small and opt-in while preserving the crate’s existing async-runtime-agnostic shape.
