### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,55 +27,55 @@ smol = ["asyncs/smol"]
 async-global-executor = ["asyncs/async-global-executor"]
 
 [dependencies]
-bytes = "1.1.0"
-thiserror = "1.0.30"
-strum = { version = "0.23", features = ["derive"] }
-num_enum = "0.5.6"
+bytes = "1.12.1"
+thiserror = "2.0.18"
+strum = { version = "0.28", features = ["derive"] }
+num_enum = "0.7.6"
 ignore-result = "0.2.0"
-compact_str = "0.4"
-const_format = "0.2.22"
+compact_str = "0.9"
+const_format = "0.2.36"
 static_assertions = "1.1.0"
-hashbrown = "0.12.0"
-hashlink = "0.8.0"
-either = "1.9.0"
-uuid = { version = "1.4.1", features = ["v4"] }
-rustls = { version =  "0.23.2", optional = true }
-rustls-webpki = { version = "0.103.4", optional = true }
+hashbrown = "0.16.1"
+hashlink = "0.11.1"
+either = "1.16.0"
+uuid = { version = "1.20.0", features = ["v4"] }
+rustls = { version =  "0.23.41", optional = true }
+rustls-webpki = { version = "0.103.13", optional = true }
 rustls-pemfile = { version = "2", optional = true }
-derive-where = "1.2.7"
-fastrand = "2.0.2"
-tracing = "0.1.40"
-rsasl = { version = "2.2.0", default-features = false, features = ["provider", "config_builder", "registry_static", "std"], optional = true }
-md5 = { version = "0.7.0", optional = true }
+derive-where = "1.6.1"
+fastrand = "2.4.1"
+tracing = "0.1.44"
+rsasl = { version = "2.3.1", default-features = false, features = ["provider", "config_builder", "registry_static", "std"], optional = true }
+md5 = { version = "0.8.0", optional = true }
 hex = { version = "0.4.3", optional = true }
 linkme = { version = "0.3", optional = true }
-async-io = "2.3.2"
-futures = "0.3.30"
+async-io = "2.6.0"
+futures = "0.3.32"
 async-net = "2.0.0"
 futures-rustls = { version = "0.26.0", optional = true }
-futures-lite = "2.3.0"
+futures-lite = "2.6.1"
 asyncs = "0.4.0"
 
 [dev-dependencies]
-test-log = { version = "0.2.18", features = ["log", "trace"] }
-env_logger = "0.10.0"
-rand = "0.8.4"
-pretty_assertions = "1.1.0"
+test-log = { version = "0.2.21", features = ["log", "trace"] }
+env_logger = "0.11.11"
+rand = "0.9.4"
+pretty_assertions = "1.4.1"
 test-case = "3"
 testcontainers = { git = "https://github.com/kezhuw/testcontainers-rs.git", branch = "zookeeper-client" }
-assertor = "0.0.2"
+assertor = "0.0.4"
 assert_matches = "1.5.0"
-tempfile = "3.6.0"
-rcgen = { version = "0.14.1", features = ["default", "x509-parser"] }
-serial_test = "3.0.0"
+tempfile = "3.27.0"
+rcgen = { version = "0.14.7", features = ["default", "x509-parser"] }
+serial_test = "3.5.0"
 asyncs = { version = "0.4.0", features = ["test"] }
-blocking = "1.6.0"
-rustls-pki-types = "1.12.0"
-x509-parser = "0.17.0"
+blocking = "1.6.2"
+rustls-pki-types = "1.15.0"
+x509-parser = "0.18.1"
 atomic-write-file = "0.2.3"
 notify = "7.0.0"
 test-fork = "0.1.3"
-rstest = "0.25.0"
+rstest = "0.26.1"
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -102,7 +102,7 @@ impl AuthId {
 
     /// Const alternative to [AuthId::new].
     pub const fn new_const(scheme: &'static str, id: &'static str) -> AuthId {
-        AuthId { scheme: CompactString::new_inline(scheme), id: CompactString::new_inline(id) }
+        AuthId { scheme: CompactString::const_new(scheme), id: CompactString::const_new(id) }
     }
 
     /// Returns the scheme this auth id serve for.
@@ -164,7 +164,7 @@ impl Acl {
     pub const fn new_const(permission: Permission, scheme: &'static str, id: &'static str) -> Acl {
         Acl {
             permission,
-            auth_id: AuthId { scheme: CompactString::new_inline(scheme), id: CompactString::new_inline(id) },
+            auth_id: AuthId { scheme: CompactString::const_new(scheme), id: CompactString::const_new(id) },
         }
     }
 

--- a/src/proto/stat.rs
+++ b/src/proto/stat.rs
@@ -123,7 +123,7 @@ impl UnsafeRead<'_> for Stat {
 
 #[cfg(test)]
 mod tests {
-    use rand::distributions::Standard;
+    use rand::distr::StandardUniform;
     use rand::Rng;
 
     use super::Stat;
@@ -131,8 +131,8 @@ mod tests {
 
     #[test]
     fn test_insufficient_buf() {
-        let rng = rand::thread_rng();
-        let data: Vec<u8> = rng.sample_iter(Standard).take(Stat::record_len() - 1).collect();
+        let rng = rand::rng();
+        let data: Vec<u8> = rng.sample_iter(StandardUniform).take(Stat::record_len() - 1).collect();
         let mut buf = data.as_slice();
         let err = Stat::deserialize(&mut buf).unwrap_err();
         assert_eq!(err, record::InsufficientBuf);
@@ -140,19 +140,19 @@ mod tests {
 
     #[test]
     fn test_serde() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let stat = Stat {
-            czxid: rng.gen(),
-            mzxid: rng.gen(),
-            ctime: rng.gen(),
-            mtime: rng.gen(),
-            version: rng.gen(),
-            cversion: rng.gen(),
-            aversion: rng.gen(),
-            ephemeral_owner: rng.gen(),
-            data_length: rng.gen(),
-            num_children: rng.gen(),
-            pzxid: rng.gen(),
+            czxid: rng.random(),
+            mzxid: rng.random(),
+            ctime: rng.random(),
+            mtime: rng.random(),
+            version: rng.random(),
+            cversion: rng.random(),
+            aversion: rng.random(),
+            ephemeral_owner: rng.random(),
+            data_length: rng.random(),
+            num_children: rng.random(),
+            pzxid: rng.random(),
         };
         let mut data = Vec::new();
         stat.serialize(&mut data);

--- a/src/sasl/mechanisms/digest_md5.rs
+++ b/src/sasl/mechanisms/digest_md5.rs
@@ -334,7 +334,7 @@ impl DigestContext<'_> {
         hasher.consume(b":auth");
         hasher.consume(b":");
         hasher.consume(Self::a2(client));
-        Self::hex(&hasher.compute().0)
+        Self::hex(&hasher.finalize().0)
     }
 
     fn client_response(&self) -> [u8; 32] {
@@ -352,14 +352,14 @@ impl DigestContext<'_> {
         hasher.consume(self.realm.as_bytes());
         hasher.consume(b":");
         hasher.consume(self.password);
-        let digest = hasher.compute();
+        let digest = hasher.finalize();
         let mut hasher = Md5Hasher::new();
         hasher.consume(digest.0);
         hasher.consume(b":");
         hasher.consume(self.nonce.as_bytes());
         hasher.consume(b":");
         hasher.consume(self.cnonce);
-        let digest = hasher.compute();
+        let digest = hasher.finalize();
         Self::hex(&digest.0)
     }
 
@@ -369,7 +369,7 @@ impl DigestContext<'_> {
             hasher.consume(b"AUTHENTICATE");
         }
         hasher.consume(b":zookeeper/zk-sasl-md5");
-        Self::hex(&hasher.compute().0)
+        Self::hex(&hasher.finalize().0)
     }
 }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -454,7 +454,7 @@ impl Session {
             self.session.id = session_id;
             info!(
                 "new session established: {} readonly={}, timeout={}ms",
-                session_id, response.readonly as bool, response.session_timeout
+                session_id, response.readonly, response.session_timeout
             );
             let span = Span::current();
             span.record("session", display(session_id));

--- a/tests/zookeeper.rs
+++ b/tests/zookeeper.rs
@@ -18,7 +18,7 @@ use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use futures::prelude::*;
 use ignore_result::Ignore;
 use pretty_assertions::assert_eq;
-use rand::distributions::Standard;
+use rand::distr::StandardUniform;
 use rand::Rng;
 use rcgen::{Certificate, CertificateParams, Issuer, KeyPair};
 use rstest::rstest;
@@ -43,8 +43,8 @@ fn env_toggle(name: &str) -> bool {
 }
 
 fn random_data() -> Vec<u8> {
-    let rng = rand::thread_rng();
-    rng.sample_iter(Standard).take(32).collect()
+    let rng = rand::rng();
+    rng.sample_iter(StandardUniform).take(32).collect()
 }
 
 fn zookeeper_image<'a>(options: ContainerOptions<'a>) -> RunnableImage<GenericImage> {


### PR DESCRIPTION
## Summary

Bump the crate direct dependency requirements to the latest available versions, including major updates where needed.

This includes `num_enum` 0.7.6 so downstream workspaces can resolve it consistently with crates such as `pgp`.

## Compatibility updates

- Replace `CompactString::new_inline` with `CompactString::const_new` for `compact_str` 0.9.
- Replace deprecated `md5::Context::compute` with `finalize` for `md5` 0.8.
- Update test helpers to the `rand` 0.9 `distr::StandardUniform`, `rng`, and `random` APIs.
- Remove an obsolete bool cast reported by clippy after the dependency updates.

## Verification

Local checks:

- `cargo +nightly fmt --all -- --check`
- `cargo fc matrix` -> 6 feature sets
- `RUSTFLAGS=-Dunused-crate-dependencies cargo build-all-features`
- `RUST_LOG=debug cargo test --features "" -- --nocapture`
- `RUST_LOG=debug cargo test --features "fips,tls" -- --nocapture`
- `RUST_LOG=debug cargo test --features "fips-only,tls" -- --nocapture`
- `RUST_LOG=debug cargo test --features "sasl" -- --nocapture`
- `RUST_LOG=debug cargo test --features "sasl,tls" -- --nocapture`
- `RUST_LOG=debug cargo test --features "tls" -- --nocapture`
- `cargo clippy --all-targets --all-features --no-deps -- -D clippy::all`
- `RUSTFLAGS=-Cinstrument-coverage cargo build --all-features --verbose`
- `LLVM_PROFILE_FILE="zookeeper-client-%p-%m.profraw" RUSTFLAGS=-Cinstrument-coverage cargo test --all-features --verbose -- --nocapture`
- `grcov $(find . -name "zookeeper-*.profraw" -print) --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info`

GitHub Actions note: upstream Actions for this fork PR are currently waiting for maintainer approval, so the Codecov upload step was not replayed locally.
