### PR TITLE
Delete lock nodes via session loop instead of spawning per drop

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -4,13 +4,14 @@ use std::borrow::Cow;
 use std::fmt::Write as _;
 use std::future::Future;
 use std::mem::ManuallyDrop;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use const_format::formatcp;
 use derive_where::derive_where;
 use either::{Either, Left, Right};
 use futures::channel::mpsc;
+use futures::future::BoxFuture;
 use ignore_result::Ignore;
 use thiserror::Error;
 use tracing::instrument;
@@ -204,6 +205,20 @@ impl CreateSequence {
     }
 }
 
+/// Session-lifetime state shared by all [`Client`] handles for one session.
+///
+/// Held behind an `Arc` so a [`WeakClient`] can reference the live session without keeping the
+/// request channel open. The channel closing (all `Client`s dropped) is how the session loop
+/// detects shutdown, so a background job must hold a `Weak`, never an `Arc`.
+#[derive(Debug)]
+struct SessionShared {
+    version: Version,
+    session: SessionInfo,
+    session_timeout: Duration,
+    requester: Arc<mpsc::UnboundedSender<Request>>,
+    state_watcher: StateWatcher,
+}
+
 /// Client encapsulates ZooKeeper session to interact with ZooKeeper cluster.
 ///
 /// Besides semantic errors, node operations could also fail due to cluster availability and
@@ -220,11 +235,19 @@ impl CreateSequence {
 #[derive(Clone, Debug)]
 pub struct Client {
     chroot: OwnedChroot,
-    version: Version,
-    session: SessionInfo,
-    session_timeout: Duration,
-    requester: Arc<mpsc::UnboundedSender<Request>>,
-    state_watcher: StateWatcher,
+    shared: Arc<SessionShared>,
+}
+
+/// Weak handle to a [`Client`]'s session. Upgrades to a full `Client` per operation so it never
+/// keeps the request channel alive; see [`WeakClient::upgrade`]. Handed to background jobs (see
+/// [`Client::spawn_background`]) so they can act on the session without outliving (or stalling the
+/// shutdown of) the client.
+#[derive(Clone, Debug)]
+struct WeakClient {
+    chroot: OwnedChroot,
+    // Stable for the life of the session, so captured here rather than read through an upgrade.
+    session_id: SessionId,
+    shared: Weak<SessionShared>,
 }
 
 impl Client {
@@ -248,7 +271,14 @@ impl Client {
         requester: Arc<mpsc::UnboundedSender<Request>>,
         state_watcher: StateWatcher,
     ) -> Client {
-        Client { chroot, version, session, session_timeout: timeout, requester, state_watcher }
+        let shared = Arc::new(SessionShared { version, session, session_timeout: timeout, requester, state_watcher });
+        Client { chroot, shared }
+    }
+
+    /// Downgrades to a [`WeakClient`] that can drive background operations without keeping the
+    /// request channel open.
+    fn downgrade(&self) -> WeakClient {
+        WeakClient { chroot: self.chroot.clone(), session_id: self.session_id(), shared: Arc::downgrade(&self.shared) }
     }
 
     fn validate_path<'a>(&'a self, path: &'a str) -> Result<ChrootPath<'a>> {
@@ -266,7 +296,7 @@ impl Client {
 
     /// ZooKeeper session info.
     pub fn session(&self) -> &SessionInfo {
-        &self.session
+        &self.shared.session
     }
 
     /// ZooKeeper session id.
@@ -276,22 +306,22 @@ impl Client {
 
     /// Consumes this instance into session info.
     pub fn into_session(self) -> SessionInfo {
-        self.session
+        self.shared.session.clone()
     }
 
     /// Negotiated session timeout.
     pub fn session_timeout(&self) -> Duration {
-        self.session_timeout
+        self.shared.session_timeout
     }
 
     /// Latest session state.
     pub fn state(&self) -> SessionState {
-        self.state_watcher.peek_state()
+        self.shared.state_watcher.peek_state()
     }
 
     /// Creates a [StateWatcher] to track future session state updates.
     pub fn state_watcher(&self) -> StateWatcher {
-        let mut watcher = self.state_watcher.clone();
+        let mut watcher = self.shared.state_watcher.clone();
         watcher.state();
         watcher
     }
@@ -318,7 +348,7 @@ impl Client {
 
     fn send_marshalled_request(&self, request: MarshalledRequest) -> StateReceiver {
         let (operation, receiver) = SessionOperation::new_marshalled(request).with_responser();
-        if let Err(err) = self.requester.unbounded_send(operation.into()) {
+        if let Err(err) = self.shared.requester.unbounded_send(operation.into()) {
             let state = self.state();
             err.into_inner().into_responser().send(Err(state.to_error()));
         }
@@ -462,7 +492,7 @@ impl Client {
             OpCode::CreateTtl
         } else if create_mode.is_container() {
             OpCode::CreateContainer
-        } else if self.version >= Version(3, 5, 0) {
+        } else if self.shared.version >= Version(3, 5, 0) {
             OpCode::Create2
         } else {
             OpCode::Create
@@ -505,51 +535,26 @@ impl Client {
         })
     }
 
-    // TODO: move these to session side so to eliminate owned Client and String.
-    fn delete_background(self, path: String) {
-        asyncs::spawn(async move {
-            self.delete_foreground(&path).await;
-        });
+    // Enqueues a fire-and-forget background job driven by the session event loop (no spawned task),
+    // so the work stays tied to the session lifecycle. Silently dropped if the session is already
+    // gone.
+    //
+    // The job body is built from a [`WeakClient`] only, so it cannot capture a strong `Client` (and
+    // its request-channel `Arc`), which would otherwise keep the channel open and block session
+    // shutdown. See `Request::BackgroundJob`.
+    fn spawn_background(&self, job: impl FnOnce(WeakClient) -> BoxFuture<'static, ()>) {
+        let job = job(self.downgrade());
+        self.shared.requester.unbounded_send(Request::BackgroundJob { job }).ignore();
     }
 
-    async fn delete_foreground(&self, path: &str) {
-        Client::retry_on_connection_loss(|| self.delete(path, None)).await.ignore();
+    // Best-effort background deletion of a single node; used for lock node cleanup on guard drop.
+    fn delete_path_background(&self, path: String) {
+        self.spawn_background(|weak| Box::pin(async move { weak.delete_foreground(&path).await }));
     }
 
-    fn delete_ephemeral_background(self, prefix: String, unique: bool) {
-        asyncs::spawn(async move {
-            let (parent, tree, name) = util::split_path(&prefix);
-            let mut children = Self::retry_on_connection_loss(|| self.list_children(parent)).await?;
-            if unique {
-                if let Some(i) = children.iter().position(|s| s.starts_with(name)) {
-                    self.delete_foreground(&children[i]).await;
-                };
-                return Ok::<(), Error>(());
-            }
-            children.retain(|s| s.starts_with(name));
-            for child in children.iter_mut() {
-                child.insert_str(0, tree);
-            }
-            let results = Self::retry_on_connection_loss(|| {
-                let mut reader = self.new_multi_reader();
-                for child in children.iter() {
-                    reader.add_get_data(child).unwrap();
-                }
-                reader.commit()
-            })
-            .await?;
-            for (i, result) in results.into_iter().enumerate() {
-                let MultiReadResult::Data { stat, .. } = result else {
-                    // It could be Error::NoNode.
-                    continue;
-                };
-                if stat.ephemeral_owner == self.session_id().0 {
-                    self.delete_foreground(&children[i]).await;
-                    break;
-                }
-            }
-            Ok(())
-        });
+    // Best-effort multi-step background cleanup of an ephemeral lock node.
+    fn delete_ephemeral_background(&self, prefix: String, unique: bool) {
+        self.spawn_background(|weak| Box::pin(weak.delete_ephemeral(prefix, unique)));
     }
 
     fn get_data_internally(
@@ -1165,6 +1170,85 @@ impl Client {
     }
 }
 
+impl WeakClient {
+    // Upgrades to a live `Client`. The strong `Client` (and its request-channel `Arc`) must be
+    // dropped before any `.await`, or an in-flight background job would keep the channel open and
+    // stall session shutdown. Callers only ever hold a `WeakClient`, and the forwarder methods
+    // below build their `'static` reply futures under a transient upgrade, so the invariant holds
+    // by construction.
+    fn upgrade(&self) -> Result<Client> {
+        match self.shared.upgrade() {
+            Some(shared) => Ok(Client { chroot: self.chroot.clone(), shared }),
+            None => Err(Error::ClientClosed),
+        }
+    }
+
+    // Forwarders: each upgrades, builds+sends synchronously, drops the strong `Client`, and returns
+    // a `'static` reply future — so awaiting them holds no `Client`.
+
+    fn list_children(&self, path: &str) -> Result<impl Future<Output = Result<Vec<String>>> + Send + 'static> {
+        Ok(Client::map_wait(self.upgrade()?.list_children_internally(path, false), |(children, _)| children))
+    }
+
+    fn multi_get_data(
+        &self,
+        paths: &[String],
+    ) -> Result<impl Future<Output = Result<Vec<MultiReadResult>>> + Send + 'static> {
+        let client = self.upgrade()?;
+        let mut reader = client.new_multi_reader();
+        for path in paths {
+            reader.add_get_data(path)?;
+        }
+        Ok(reader.commit())
+    }
+
+    fn delete(&self, path: &str) -> Result<impl Future<Output = Result<()>> + Send + 'static> {
+        self.upgrade()?.delete_internally(path, None)
+    }
+
+    async fn delete_foreground(&self, path: &str) {
+        Client::retry_on_connection_loss(|| async { Client::wait(self.delete(path)).await }).await.ignore();
+    }
+
+    // Deletes the ephemeral lock node created under `prefix`. Lists the siblings sharing `prefix`'s
+    // trailing name; when `unique`, the sole match is ours, otherwise a multi-read picks the one
+    // owned by this session. Best-effort. Each step re-upgrades and drops before awaiting, so the
+    // job never holds the request channel open.
+    async fn delete_ephemeral(self, prefix: String, unique: bool) {
+        let result: Result<()> = async {
+            let (parent, tree, name) = util::split_path(&prefix);
+            let mut children =
+                Client::retry_on_connection_loss(|| async { Client::wait(self.list_children(parent)).await }).await?;
+            if unique {
+                if let Some(i) = children.iter().position(|s| s.starts_with(name)) {
+                    self.delete_foreground(&children[i]).await;
+                };
+                return Ok(());
+            }
+            children.retain(|s| s.starts_with(name));
+            for child in children.iter_mut() {
+                child.insert_str(0, tree);
+            }
+            let results =
+                Client::retry_on_connection_loss(|| async { Client::wait(self.multi_get_data(&children)).await })
+                    .await?;
+            for (i, result) in results.into_iter().enumerate() {
+                let MultiReadResult::Data { stat, .. } = result else {
+                    // It could be Error::NoNode.
+                    continue;
+                };
+                if stat.ephemeral_owner == self.session_id.0 {
+                    self.delete_foreground(&children[i]).await;
+                    break;
+                }
+            }
+            Ok(())
+        }
+        .await;
+        result.ignore();
+    }
+}
+
 /// Options to cover [Acls] for lock path and [CreateOptions] for ancestor nodes if they don't
 /// exist.
 #[derive(Clone, Debug)]
@@ -1322,7 +1406,7 @@ struct LockingGuard<'a> {
 
 impl Drop for LockingGuard<'_> {
     fn drop(&mut self) {
-        self.zk.clone().delete_ephemeral_background(self.prefix.to_string(), self.unique);
+        self.zk.delete_ephemeral_background(self.prefix.to_string(), self.unique);
     }
 }
 
@@ -1449,29 +1533,30 @@ impl<'a> LockClient<'a> {
     /// Converts to [OwnedLockClient].
     pub fn into_owned(self) -> OwnedLockClient {
         let client = self.client.clone();
+        // Suppress `Drop for LockClient`, otherwise conversion would delete the lock path.
         let mut drop = ManuallyDrop::new(self);
         let lock = std::mem::take(drop.lock.to_mut());
-        OwnedLockClient { client: ManuallyDrop::new(client), lock }
+        OwnedLockClient { client, lock }
     }
 }
 
 /// Deletes lock path in background.
 impl Drop for LockClient<'_> {
     fn drop(&mut self) {
-        let path = std::mem::take(self.lock.to_mut());
-        let client = self.client.clone();
-        client.delete_background(path);
+        self.client.delete_path_background(std::mem::take(self.lock.to_mut()));
     }
 }
 
 /// Owned version of [LockClient].
 #[derive(Clone, Debug)]
 pub struct OwnedLockClient {
-    client: ManuallyDrop<Client>,
+    client: Client,
     lock: String,
 }
 
 impl OwnedLockClient {
+    // Wrapped in `ManuallyDrop` so the temporary `LockClient` does not fire its lock-deleting
+    // `Drop` when this borrow ends; the lock is deleted only when the `OwnedLockClient` drops.
     fn lock_client(&self) -> std::mem::ManuallyDrop<LockClient<'_>> {
         std::mem::ManuallyDrop::new(LockClient { client: &self.client, lock: Cow::from(&self.lock) })
     }
@@ -1520,9 +1605,7 @@ impl OwnedLockClient {
 /// Deletes lock path in background.
 impl Drop for OwnedLockClient {
     fn drop(&mut self) {
-        let client = unsafe { ManuallyDrop::take(&mut self.client) };
-        let path = std::mem::take(&mut self.lock);
-        client.delete_background(path);
+        self.client.delete_path_background(std::mem::take(&mut self.lock));
     }
 }
 
@@ -1890,7 +1973,7 @@ impl<'a> MultiReader<'a> {
     ///
     /// # Notable behaviors
     /// Individual errors(e.g. [Error::NoNode]) are reported individually through [MultiReadResult::Error].
-    pub fn commit(&mut self) -> impl Future<Output = Result<Vec<MultiReadResult>>> + Send + 'a {
+    pub fn commit(&mut self) -> impl Future<Output = Result<Vec<MultiReadResult>>> + Send + 'static {
         let request = self.build_request();
         Client::resolve(self.commit_internally(request))
     }
@@ -1898,7 +1981,7 @@ impl<'a> MultiReader<'a> {
     fn commit_internally(
         &self,
         request: MarshalledRequest,
-    ) -> Result<Either<impl Future<Output = Result<Vec<MultiReadResult>>> + Send + 'a, Vec<MultiReadResult>>> {
+    ) -> Result<Either<impl Future<Output = Result<Vec<MultiReadResult>>> + Send + 'static, Vec<MultiReadResult>>> {
         if request.is_empty() {
             return Ok(Right(Vec::default()));
         }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -13,6 +13,8 @@ use std::time::{Duration, Instant};
 use async_io::Timer;
 use asyncs::{select, sync};
 use futures::channel::mpsc;
+use futures::future::BoxFuture;
+use futures::stream::FuturesUnordered;
 use futures::{AsyncWriteExt, StreamExt};
 use ignore_result::Ignore;
 use tracing::field::display;
@@ -150,6 +152,7 @@ impl Builder {
             authes: self.authes,
             state_sender,
             watch_manager,
+            background_jobs: FuturesUnordered::new(),
         };
         let timeout = if self.session_timeout.is_zero() { DEFAULT_SESSION_TIMEOUT } else { self.session_timeout };
         session.reset_timeout(timeout);
@@ -186,6 +189,11 @@ pub struct Session {
     state_sender: sync::watch::Sender<SessionState>,
 
     watch_manager: WatchManager,
+
+    /// Fire-and-forget background jobs (e.g. lock node cleanup on guard drop) driven by the
+    /// event loop instead of spawned tasks. Best-effort: in-flight jobs are dropped on session
+    /// termination.
+    background_jobs: FuturesUnordered<BoxFuture<'static, ()>>,
 }
 
 impl Session {
@@ -560,6 +568,10 @@ impl Session {
                     r?;
                     self.last_send = Instant::now();
                 },
+                // Drive background jobs (e.g. lock node cleanup on guard drop). The guard is
+                // required: `FuturesUnordered::next` yields `Ready(None)` when empty, which would
+                // busy-spin the loop otherwise (mirrors `seek_for_writable` above).
+                _ = self.background_jobs.next(), if !self.background_jobs.is_empty() => {},
                 r = requester.next(), if !channel_halted => match r {
                     None => {
                         if !self.detached {
@@ -573,6 +585,7 @@ impl Session {
                     }) => {
                         self.watch_manager.remove_watcher(id, responser, depot);
                     }
+                    Some(Request::BackgroundJob { job }) => self.background_jobs.push(job),
                 },
                 now = tick.as_mut() => {
                     if now >= self.last_recv + self.connector.timeout() {

--- a/src/session/request.rs
+++ b/src/session/request.rs
@@ -4,6 +4,7 @@ use std::task::{Context, Poll};
 
 use bytes::{Buf, BufMut};
 use futures::channel::oneshot;
+use futures::future::BoxFuture;
 use ignore_result::Ignore;
 
 use super::types::WatchMode;
@@ -128,7 +129,17 @@ pub enum Operation {
 
 pub enum Request {
     Session(SessionOperation),
-    RemoveWatcher { id: WatcherId, responser: StateResponser },
+    RemoveWatcher {
+        id: WatcherId,
+        responser: StateResponser,
+    },
+    /// Fire-and-forget background job driven to completion by the session event loop instead of a
+    /// spawned task, so it stays tied to the session lifecycle. The job must hold only a weak
+    /// client handle, never keeping the request channel open, otherwise it would block session
+    /// shutdown (the channel closing is how the loop learns all clients are gone).
+    BackgroundJob {
+        job: BoxFuture<'static, ()>,
+    },
 }
 
 impl From<SessionOperation> for Request {
@@ -142,6 +153,7 @@ impl Request {
         match self {
             Self::Session(operation) => operation.responser,
             Self::RemoveWatcher { responser, .. } => responser,
+            Self::BackgroundJob { .. } => StateResponser::none(),
         }
     }
 }

--- a/tests/zookeeper.rs
+++ b/tests/zookeeper.rs
@@ -1032,6 +1032,28 @@ async fn test_lock_curator_filter() {
     let _lock = client.lock(lock_prefix, b"", options).await.unwrap();
 }
 
+/// Dropping the last client right after dropping a lock guard must still terminate the session
+/// promptly; lock node cleanup on drop must not delay shutdown.
+#[asyncs::test]
+#[test_log::test]
+async fn test_lock_drop_then_close_terminates() {
+    let cluster = Cluster::new().await;
+    let client = cluster.client(None).await;
+    let options = zk::LockOptions::new(zk::Acls::anyone_all()).with_ancestor_options(CONTAINER_OPEN.clone()).unwrap();
+
+    let lock_prefix = zk::LockPrefix::new_curator("/locks/curator", "lock-").unwrap();
+    let lock = client.lock(lock_prefix, b"", options).await.unwrap();
+
+    // Subscribe before dropping so we can still observe state after the client is gone.
+    let mut state_watcher = client.state_watcher();
+
+    drop(lock);
+    drop(client);
+
+    // Times out if the session fails to terminate.
+    state_watcher.wait(zk::SessionState::Closed, Some(Duration::from_secs(30))).await;
+}
+
 #[allow(unused_must_use)] // semi-asynchronous future
 async fn test_lock_with_path(
     cluster: &Cluster,


### PR DESCRIPTION
Lock guards (LockClient, OwnedLockClient, LockingGuard) deleted their
ZooKeeper nodes on drop by spawning a detached task, decoupled from the
session event loop that already owns the connection. Drive the cleanup
from that loop instead, mirroring the existing RemovableWatcher-on-drop
pattern:

- Add a single fire-and-forget Request::BackgroundJob carrying a boxed
  future. The Session owns a FuturesUnordered of these jobs, polled by a
  gated select! arm (guarded like seek_for_writable so an empty set does
  not busy-spin), and drops the request onto the existing channel with no
  spawn. Best-effort: in-flight jobs are dropped on session termination.
- Split Client into a shared Arc<SessionShared> plus a WeakClient handle.
  A background job holds only a WeakClient, so it never keeps the request
  channel open; the channel closing is how the loop learns all clients
  are gone and can shut down. WeakClient forwarder methods upgrade for a
  single request and drop the strong Client before awaiting, returning
  'static futures.
- spawn_background takes a FnOnce(WeakClient) -> BoxFuture builder, so a
  job body cannot capture a strong Client from the enclosing scope. Both
  the single-node delete and the multi-step ephemeral cleanup build their
  chroot-translated futures on the client this way.

Since the job no longer needs an owned Client and String to spawn with,
OwnedLockClient.client becomes a plain Client, dropping the ManuallyDrop
wrapper and its unsafe Drop impl.

Lock integration tests pass under tokio and smol, including all chroot
cases.

Resolves #44.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
